### PR TITLE
Add slug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /build
 /node_modules
+web/node_modules
+web/.next
+web/package-lock.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "inti",
+  "name": "inte",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "inti",
+      "name": "inte",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
@@ -13,7 +13,7 @@
         "zod": "^3.25.76"
       },
       "bin": {
-        "inti": "build/index.js"
+        "inte": "build/index.js"
       },
       "devDependencies": {
         "@types/node": "^22.17.0",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "inti",
+  "name": "inte",
   "version": "1.0.0",
   "main": "index.js",
   "type": "module",
   "bin": {
-    "inti": "./build/index.js"
+    "inte": "./build/index.js"
   },
   "scripts": {
     "build": "tsc && chmod 755 build/index.js"

--- a/snippets/github/metadata.json
+++ b/snippets/github/metadata.json
@@ -3,5 +3,5 @@
   "language": "JavaScript",
   "topics": ["version control", "api", "nodejs"],
   "lastUpdated": "2025-07-30",
-  "slug": "github/javascript"
+  "slug": "github"
 }

--- a/snippets/stripe/metadata.json
+++ b/snippets/stripe/metadata.json
@@ -3,5 +3,5 @@
   "language": "JavaScript",
   "topics": ["payments", "api", "nodejs"],
   "lastUpdated": "2025-07-30",
-  "slug": "stripe/javascript"
+  "slug": "stripe"
 }

--- a/snippets/twilio/metadata.json
+++ b/snippets/twilio/metadata.json
@@ -3,5 +3,5 @@
   "language": "JavaScript",
   "topics": ["sms", "api", "nodejs"],
   "lastUpdated": "2025-07-30",
-  "slug": "twilio/javascript"
+  "slug": "twilio"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ const SNIPPETS_DIR = path.resolve(__dirname, "../snippets");
 
 // Create server instance
 const server = new McpServer({
-  name: "inti",
+  name: "inte",
   version: "1.0.0",
   capabilities: {
     resources: ["listVendors", "getSnippet"],
@@ -38,12 +38,8 @@ server.tool(
       const vendorsDirs = await fs.readdir(SNIPPETS_DIR, { withFileTypes: true });
       for (const vendor of vendorsDirs) {
         if (!vendor.isDirectory()) continue;
-        const langDirs = await fs.readdir(path.join(SNIPPETS_DIR, vendor.name), { withFileTypes: true });
-        for (const lang of langDirs) {
-          if (!lang.isDirectory()) continue;
-          const meta = await readMetadata(path.join(SNIPPETS_DIR, vendor.name, lang.name));
-          if (meta) vendors.push(meta);
-        }
+        const meta = await readMetadata(path.join(SNIPPETS_DIR, vendor.name));
+        if (meta) vendors.push(meta);
       }
     } catch (err) {
       return {
@@ -63,7 +59,7 @@ server.tool(
 server.tool(
   "getSnippet",
   "Get snippet markdown for a vendor",
-  { vendorName: z.string().describe("Vendor and language slug") },
+  { vendorName: z.string().describe("Vendor slug") },
   async ({ vendorName }) => {
     const snippetPath = path.join(SNIPPETS_DIR, vendorName, "snippet.md");
     try {

--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "inte-web",
+  "private": true,
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "^14.0.4",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-markdown": "^9.0.0"
+  }
+}

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+
+interface Vendor {
+  vendorName: string;
+  language: string;
+  topics: string[];
+  slug: string;
+}
+
+export default function Home() {
+  const [vendors, setVendors] = useState<Vendor[]>([]);
+  const [query, setQuery] = useState('');
+  const [selected, setSelected] = useState<Vendor | null>(null);
+  const [snippet, setSnippet] = useState('');
+
+  useEffect(() => {
+    fetch('/metadata.json').then(res => res.json()).then(setVendors);
+  }, []);
+
+  const filtered = vendors.filter(v => {
+    const q = query.toLowerCase();
+    return (
+      v.vendorName.toLowerCase().includes(q) ||
+      v.topics.some(t => t.toLowerCase().includes(q))
+    );
+  });
+
+  const loadSnippet = async (slug: string) => {
+    setSnippet('Loading...');
+    const url = `https://raw.githubusercontent.com/neiltthomas/inte/main/snippets/${slug}/snippet.md`;
+    const res = await fetch(url);
+    setSnippet(await res.text());
+  };
+
+  return (
+    <div>
+      <h1>Integration Snippets</h1>
+      <input
+        type="text"
+        placeholder="Search"
+        value={query}
+        onChange={e => setQuery(e.target.value)}
+      />
+      <ul>
+        {filtered.map(v => (
+          <li key={v.slug}>
+            <button
+              onClick={() => {
+                setSelected(v);
+                loadSnippet(v.slug);
+              }}
+            >
+              {v.vendorName}
+            </button>
+          </li>
+        ))}
+      </ul>
+      {selected && (
+        <div>
+          <h2>{selected.vendorName}</h2>
+          <ReactMarkdown>{snippet}</ReactMarkdown>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/public/metadata.json
+++ b/web/public/metadata.json
@@ -1,0 +1,35 @@
+[
+  {
+    "vendorName": "GitHub",
+    "language": "JavaScript",
+    "topics": [
+      "version control",
+      "api",
+      "nodejs"
+    ],
+    "lastUpdated": "2025-07-30",
+    "slug": "github"
+  },
+  {
+    "vendorName": "Stripe",
+    "language": "JavaScript",
+    "topics": [
+      "payments",
+      "api",
+      "nodejs"
+    ],
+    "lastUpdated": "2025-07-30",
+    "slug": "stripe"
+  },
+  {
+    "vendorName": "Twilio",
+    "language": "JavaScript",
+    "topics": [
+      "sms",
+      "api",
+      "nodejs"
+    ],
+    "lastUpdated": "2025-07-30",
+    "slug": "twilio"
+  }
+]

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "es2022"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- stop assuming language subfolders for snippets
- update metadata and slug handling in web app and server
- ignore web `package-lock.json`
- rename `inti` references to `inte` for consistent project naming

## Testing
- `npm run build`
- `npm install && npm run build` in `web`


------
https://chatgpt.com/codex/tasks/task_e_688d0d53bc68832d865b04dd00e54717