### PR TITLE
Fix project URLs to new GitHub repo

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod";
 
 const BASE_URL =
-  "https://raw.githubusercontent.com/neiltthomas/inte/main/snippets";
+  "https://raw.githubusercontent.com/neilthomass/Inte/main/snippets";
 
 // Create server instance
 const server = new McpServer({

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -15,7 +15,7 @@ export default function Home() {
   const [snippet, setSnippet] = useState('');
 
   useEffect(() => {
-    fetch('https://raw.githubusercontent.com/neiltthomas/inte/main/snippets/metadata.json')
+    fetch('https://raw.githubusercontent.com/neilthomass/Inte/main/snippets/metadata.json')
       .then(res => res.json())
       .then(setVendors);
   }, []);
@@ -30,7 +30,7 @@ export default function Home() {
 
   const loadSnippet = async (slug: string) => {
     setSnippet('Loading...');
-    const url = `https://raw.githubusercontent.com/neiltthomas/inte/main/snippets/${slug}/snippet.md`;
+    const url = `https://raw.githubusercontent.com/neilthomass/Inte/main/snippets/${slug}/snippet.md`;
     const res = await fetch(url);
     setSnippet(await res.text());
   };


### PR DESCRIPTION
## Summary
- update the base repository URL to `https://github.com/neilthomass/Inte`

## Testing
- `npm run build`
- `npm --prefix web run build`


------
https://chatgpt.com/codex/tasks/task_e_688d1b68499c832db5f3caf6f0f498f7