### PR TITLE
Expand snippet docs

### DIFF
--- a/snippets/discord/snippet.md
+++ b/snippets/discord/snippet.md
@@ -35,3 +35,24 @@ const embed = {
 
 await webhook.send({ embeds: [embed] });
 ```
+Handle message updates:
+
+```javascript
+const message = await webhook.send({ content: 'Initial message' });
+await webhook.editMessage(message.id, { content: 'Updated content' });
+```
+
+Listen for bot commands:
+
+```javascript
+const { Client, GatewayIntentBits } = require('discord.js');
+const client = new Client({ intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages] });
+
+client.on('messageCreate', (msg) => {
+  if (msg.content === '!ping') {
+    msg.reply('Pong!');
+  }
+});
+
+client.login(process.env.DISCORD_BOT_TOKEN);
+```

--- a/snippets/github/snippet.md
+++ b/snippets/github/snippet.md
@@ -19,3 +19,24 @@ Create issue:
 ```javascript
 await octokit.issues.create({ owner: 'org', repo: 'repo', title: 'New issue' });
 ```
+
+Add collaborators:
+
+```javascript
+await octokit.repos.addCollaborator({
+  owner: 'org',
+  repo: 'repo',
+  username: 'friend',
+  permission: 'push'
+});
+```
+
+Handle pagination:
+
+```javascript
+for await (const response of octokit.paginate.iterator(octokit.repos.listForAuthenticatedUser)) {
+  for (const repo of response.data) {
+    console.log(repo.full_name);
+  }
+}
+```

--- a/snippets/openai/snippet.md
+++ b/snippets/openai/snippet.md
@@ -34,3 +34,20 @@ const embedding = await openai.embeddings.create({
 
 const vector = embedding.data[0].embedding;
 ```
+Stream completions:
+
+```javascript
+for await (const chunk of openai.beta.chat.completions.stream({
+  model: 'gpt-3.5-turbo',
+  messages: [{ role: 'user', content: 'Tell me a joke' }]
+})) {
+  process.stdout.write(chunk.choices[0]?.delta?.content || '');
+}
+```
+
+Check moderation:
+
+```javascript
+const moderation = await openai.moderations.create({ input: 'Some text' });
+console.log(moderation.results[0].flagged);
+```

--- a/snippets/sendgrid/snippet.md
+++ b/snippets/sendgrid/snippet.md
@@ -33,3 +33,30 @@ const messages = [
 
 await sgMail.send(messages);
 ```
+Add attachments:
+
+```javascript
+const fileData = require('fs').readFileSync('./invoice.pdf').toString('base64');
+await sgMail.send({
+  ...msg,
+  attachments: [
+    {
+      content: fileData,
+      filename: 'invoice.pdf',
+      type: 'application/pdf',
+      disposition: 'attachment'
+    }
+  ]
+});
+```
+
+Check email statistics:
+
+```javascript
+const stats = await sgMail.client.request({
+  method: 'GET',
+  url: '/v3/stats',
+  qs: { start_date: '2024-01-01', end_date: '2024-01-31' }
+});
+console.log(stats[1]);
+```

--- a/snippets/stripe/snippet.md
+++ b/snippets/stripe/snippet.md
@@ -18,3 +18,36 @@ List charges:
 ```javascript
 const charges = await stripe.charges.list({ limit: 5 });
 ```
+
+Create payment intent:
+
+```javascript
+const paymentIntent = await stripe.paymentIntents.create({
+  amount: 2000,
+  currency: 'usd',
+  automatic_payment_methods: { enabled: true }
+});
+```
+
+Handle webhook events:
+
+```javascript
+const express = require('express');
+const app = express();
+app.post('/webhook', express.raw({ type: 'application/json' }), (req, res) => {
+  const sig = req.headers['stripe-signature'];
+  let event;
+  try {
+    event = stripe.webhooks.constructEvent(
+      req.body,
+      sig,
+      process.env.STRIPE_WEBHOOK_SECRET
+    );
+  } catch (err) {
+    res.status(400).send(`Webhook Error: ${err.message}`);
+    return;
+  }
+  // handle event types
+  res.json({ received: true });
+});
+```

--- a/snippets/twilio/snippet.md
+++ b/snippets/twilio/snippet.md
@@ -19,3 +19,20 @@ Fetch message list:
 ```javascript
 const messages = await client.messages.list({ limit: 5 });
 ```
+
+Check delivery status:
+
+```javascript
+const status = await client.messages('SM123').fetch();
+console.log(status.status);
+```
+
+Make a voice call:
+
+```javascript
+await client.calls.create({
+  twiml: '<Response><Say>Hello!</Say></Response>',
+  from: '+10000000000',
+  to: '+19999999999'
+});
+```


### PR DESCRIPTION
## Summary
- expand Discord integration snippet with message edits and bot examples
- add collaborator and pagination instructions in GitHub snippet
- include streaming and moderation usage in OpenAI snippet
- provide SendGrid attachment and stats examples
- show Stripe payment intents and webhook handling
- extend Twilio snippet with delivery status and voice calls

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688d3724ea40832db5a0b928c589cfb3